### PR TITLE
feature: Add support for refresh tokens and Client Credentials flow

### DIFF
--- a/src/main/java/com/github/philippheuer/credentialmanager/identityprovider/OAuth2IdentityProvider.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/identityprovider/OAuth2IdentityProvider.java
@@ -310,7 +310,130 @@ public abstract class OAuth2IdentityProvider extends IdentityProvider {
             throw new RuntimeException(ex);
         }
     }
-
+    
+    
+    /**
+     * Refresh access token using refresh token
+     *
+     * @param oldCredential The credential to refresh
+     * @return The refreshed credential
+     * @throws UnsupportedOperationException If the token endpoint type is not "QUERY" or "BODY", or if the credential has no refresh token.
+     * @throws RuntimeException If the response is unsuccessful
+     */
+    public Optional<OAuth2Credential> refreshCredential(OAuth2Credential oldCredential) {
+        // request access token
+        OkHttpClient client = new OkHttpClient();
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        try {
+            Request request;
+            
+            if(oldCredential.getRefreshToken() == null) throw new UnsupportedOperationException("Attempting to refresh a credential that has no refresh token.");
+            
+            if (tokenEndpointPostType.equalsIgnoreCase("QUERY")) {
+                HttpUrl.Builder urlBuilder = HttpUrl.parse(this.tokenUrl).newBuilder();
+                urlBuilder.addQueryParameter("client_id", this.clientId);
+                urlBuilder.addQueryParameter("client_secret", this.clientSecret);
+                urlBuilder.addQueryParameter("refresh_token", oldCredential.getRefreshToken());
+                urlBuilder.addQueryParameter("grant_type", "refresh_token");
+                
+                request = new Request.Builder()
+                        .url(urlBuilder.build().toString())
+                        .post(RequestBody.create(null, new byte[]{}))
+                        .build();
+            } else if (tokenEndpointPostType.equalsIgnoreCase("BODY")) {
+                RequestBody requestBody = new MultipartBody.Builder()
+                        .setType(MultipartBody.FORM)
+                        .addFormDataPart("client_id", this.clientId)
+                        .addFormDataPart("client_secret", this.clientSecret)
+                        .addFormDataPart("refresh_token", oldCredential.getRefreshToken())
+                        .addFormDataPart("grant_type", "refresh_token")
+                        .build();
+                
+                request = new Request.Builder()
+                        .url(this.tokenUrl)
+                        .post(requestBody)
+                        .build();
+            } else {
+                throw new UnsupportedOperationException("Unknown tokenEndpointPostType: " + tokenEndpointPostType);
+            }
+            
+            Response response = client.newCall(request).execute();
+            String responseBody = response.body().string();
+            if (response.isSuccessful()) {
+                Map<String, Object> resultMap = objectMapper.readValue(responseBody, new TypeReference<HashMap<String, Object>>() {});
+                
+                OAuth2Credential credential = new OAuth2Credential(this.providerName, (String) resultMap.get("access_token"), (String) resultMap.get("refresh_token"), null, null, (Integer) resultMap.get("expires_in"), null);
+                return Optional.of(credential);
+            } else {
+                throw new RuntimeException("refreshCredential request failed! " + response.code() + ": " + responseBody);
+            }
+            
+        } catch (Exception ex) {
+        
+        }
+        
+        return Optional.empty();
+    }
+    
+    
+    /**
+     * Get a Credential for server-to-server requests using the OAuth2 Client Credentials Flow.
+     *
+     * @return The refreshed credential
+     * @throws UnsupportedOperationException If the token endpoint type is not "QUERY" or "BODY"
+     * @throws RuntimeException If the response is unsuccessful
+     */
+    public OAuth2Credential getAppAccessToken() {
+        // request access token
+        OkHttpClient client = new OkHttpClient();
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        try {
+            Request request;
+            
+            if (tokenEndpointPostType.equalsIgnoreCase("QUERY")) {
+                HttpUrl.Builder urlBuilder = HttpUrl.parse(this.tokenUrl).newBuilder();
+                urlBuilder.addQueryParameter("client_id", this.clientId);
+                urlBuilder.addQueryParameter("client_secret", this.clientSecret);
+                urlBuilder.addQueryParameter("grant_type", "client_credentials");
+                
+                request = new Request.Builder()
+                        .url(urlBuilder.build().toString())
+                        .post(RequestBody.create(null, new byte[]{}))
+                        .build();
+            } else if (tokenEndpointPostType.equalsIgnoreCase("BODY")) {
+                RequestBody requestBody = new MultipartBody.Builder()
+                        .setType(MultipartBody.FORM)
+                        .addFormDataPart("client_id", this.clientId)
+                        .addFormDataPart("client_secret", this.clientSecret)
+                        .addFormDataPart("grant_type", "client_credentials")
+                        .build();
+                
+                request = new Request.Builder()
+                        .url(this.tokenUrl)
+                        .post(requestBody)
+                        .build();
+            } else {
+                throw new UnsupportedOperationException("Unknown tokenEndpointPostType: " + tokenEndpointPostType);
+            }
+            
+            Response response = client.newCall(request).execute();
+            String responseBody = response.body().string();
+            if (response.isSuccessful()) {
+                Map<String, Object> resultMap = objectMapper.readValue(responseBody, new TypeReference<HashMap<String, Object>>() {});
+                
+                OAuth2Credential credential = new OAuth2Credential(this.providerName, (String) resultMap.get("access_token"), (String) resultMap.get("refresh_token"), null, null, (Integer) resultMap.get("expires_in"), null);
+                return credential;
+            } else {
+                throw new RuntimeException("getCredentialByClientCredentials request failed! " + response.code() + ": " + responseBody);
+            }
+            
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    
     /**
      * Get Token Information
      *


### PR DESCRIPTION
This will be the first step in supporting Webhooks in twitch4j. I have been using the refresh feature for a while, and just tested the App Access token feature today and it worked fine. The code is just copied from the other methods already in the class, with the appropriate changes for the relevant flow type.