### PR TITLE
feat: implement device authorization grant flow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
 
     // Logging
     api("org.slf4j:slf4j-api:2.0.9")
+    testImplementation("org.slf4j:slf4j-simple:2.0.9")
 
     // Commons Lang
     implementation("org.apache.commons:commons-lang3:3.14.0")

--- a/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
@@ -42,9 +42,8 @@ public final class DeviceFlowController extends AuthenticationController impleme
     @Override
     public DeviceAuthorization startOAuth2DeviceAuthorizationGrantType(OAuth2IdentityProvider oAuth2IdentityProvider, Collection<Object> scopes, Consumer<DeviceTokenResponse> callback) {
         DeviceAuthorization request = oAuth2IdentityProvider.createDeviceFlowRequest(scopes);
-        Instant expiry = Instant.now().plusSeconds(request.getExpiresIn());
         AtomicInteger interval = new AtomicInteger(request.getInterval());
-        schedule(oAuth2IdentityProvider, request.getDeviceCode(), request.getUserCode(), expiry, interval, callback);
+        schedule(oAuth2IdentityProvider, request.getDeviceCode(), request.getUserCode(), request.getExpiresAt(), interval, callback);
         return request;
     }
 

--- a/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
@@ -56,7 +56,7 @@ public final class DeviceFlowController extends AuthenticationController impleme
     public void close() {
         this.closed = true;
         if (this.shouldCloseExecutor) {
-            this.executor.close();
+            this.executor.shutdownNow();
         }
     }
 

--- a/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
@@ -1,0 +1,110 @@
+package com.github.philippheuer.credentialmanager.authcontroller;
+
+import com.github.philippheuer.credentialmanager.CredentialManager;
+import com.github.philippheuer.credentialmanager.domain.AuthenticationController;
+import com.github.philippheuer.credentialmanager.domain.DeviceAuthorization;
+import com.github.philippheuer.credentialmanager.domain.DeviceFlowError;
+import com.github.philippheuer.credentialmanager.domain.DeviceTokenResponse;
+import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
+import com.github.philippheuer.credentialmanager.identityprovider.OAuth2IdentityProvider;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+/**
+ * Facilitates the Device Authorization Grant Flow; repeatedly checks if the device token is available.
+ */
+@Slf4j
+public final class DeviceFlowController extends AuthenticationController implements Closeable {
+
+    private final ScheduledExecutorService executor;
+    private boolean shouldCloseExecutor = false;
+    private volatile boolean closed = false;
+
+    public DeviceFlowController() {
+        this(Executors.newSingleThreadScheduledExecutor());
+        this.shouldCloseExecutor = true;
+    }
+
+    public DeviceFlowController(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public DeviceAuthorization startOAuth2DeviceAuthorizationGrantType(OAuth2IdentityProvider oAuth2IdentityProvider, Collection<Object> scopes, Consumer<DeviceTokenResponse> callback) {
+        DeviceAuthorization request = oAuth2IdentityProvider.createDeviceFlowRequest(scopes);
+        Instant expiry = Instant.now().plusSeconds(request.getExpiresIn());
+        AtomicInteger interval = new AtomicInteger(request.getInterval());
+        schedule(oAuth2IdentityProvider, request.getDeviceCode(), request.getUserCode(), expiry, interval, callback);
+        return request;
+    }
+
+    @Override
+    public void startOAuth2AuthorizationCodeGrantType(OAuth2IdentityProvider oAuth2IdentityProvider, String redirectUrl, List<Object> scopes) {
+        throw new UnsupportedOperationException("This controller only facilitates the Device Authorization Grant Flow.");
+    }
+
+    @Override
+    public void close() {
+        this.closed = true;
+        if (this.shouldCloseExecutor) {
+            this.executor.close();
+        }
+    }
+
+    private void schedule(OAuth2IdentityProvider identityProvider, String deviceCode, String userCode, Instant expiry, AtomicInteger interval, Consumer<DeviceTokenResponse> callback) {
+        executor.schedule(() -> {
+            if (this.closed) {
+                log.info("Cancelling device code flow for user {} since controller was closed", userCode);
+                callback.accept(null);
+                return;
+            }
+
+            if (Instant.now().isAfter(expiry)) {
+                callback.accept(new DeviceTokenResponse(null, DeviceFlowError.EXPIRED_TOKEN));
+                return;
+            }
+
+            try {
+                DeviceTokenResponse response = identityProvider.getDeviceAccessToken(deviceCode);
+                OAuth2Credential credential = response.getCredential();
+                assert credential != null || response.getError() != null;
+                if (credential != null || !response.getError().shouldRetry()) {
+                    callback.accept(response);
+
+                    CredentialManager credentialManager = getCredentialManager();
+                    if (credential != null && credentialManager != null) {
+                        credentialManager.addCredential(identityProvider.getProviderName(), credential);
+                    }
+                } else {
+                    log.debug("Received {} error from device token endpoint for user {}; will retry...", response.getError(), userCode);
+                    if (response.getError() == DeviceFlowError.SLOW_DOWN) {
+                        interval.addAndGet(5);
+                    }
+                }
+            } catch (Exception e) {
+                log.warn("Encountered exception when checking for device access token; will retry...", e);
+
+                if (e.getCause() instanceof IOException) {
+                    // On encountering a connection timeout, clients MUST unilaterally reduce their polling
+                    // frequency before retrying. The use of an exponential backoff algorithm to achieve this,
+                    // such as doubling the polling interval on each such connection timeout, is RECOMMENDED.
+                    // https://datatracker.ietf.org/doc/html/rfc8628#section-3.5
+                    interval.updateAndGet(i -> i <= 30 ? i * 2 : i + 10);
+                }
+            }
+
+            // try again later
+            this.schedule(identityProvider, deviceCode, userCode, expiry, interval, callback);
+        }, interval.get(), TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
@@ -9,7 +9,7 @@ import com.github.philippheuer.credentialmanager.domain.OAuth2Credential;
 import com.github.philippheuer.credentialmanager.identityprovider.OAuth2IdentityProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.compare.ComparableUtils;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -30,26 +30,31 @@ public final class DeviceFlowController extends AuthenticationController impleme
 
     private final int maxExpiresIn;
     private final ScheduledExecutorService executor;
-    private boolean shouldCloseExecutor = false;
+    private final boolean shouldCloseExecutor;
     private volatile boolean closed = false;
 
     /**
      * Creates a {@link DeviceFlowController} with default settings.
      */
     public DeviceFlowController() {
-        this(Executors.newSingleThreadScheduledExecutor(), 0);
-        this.shouldCloseExecutor = true;
+        this(null, 0);
     }
 
     /**
      * Creates a {@link DeviceFlowController} with the specified executor and maximum expiry seconds.
      *
-     * @param executor     a not-null {@link ScheduledExecutorService}
+     * @param executor     an optional {@link ScheduledExecutorService}
      * @param maxExpiresIn the maximum duration in seconds to repeatedly request a device token; ignored if not positive
      */
-    public DeviceFlowController(@NotNull ScheduledExecutorService executor, int maxExpiresIn) {
-        this.executor = executor;
+    public DeviceFlowController(@Nullable ScheduledExecutorService executor, int maxExpiresIn) {
         this.maxExpiresIn = maxExpiresIn;
+        if (executor != null) {
+            this.executor = executor;
+            this.shouldCloseExecutor = false;
+        } else {
+            this.executor = Executors.newSingleThreadScheduledExecutor();
+            this.shouldCloseExecutor = true;
+        }
     }
 
     @Override

--- a/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowController.java
@@ -85,6 +85,7 @@ public final class DeviceFlowController extends AuthenticationController impleme
                     if (credential != null && credentialManager != null) {
                         credentialManager.addCredential(identityProvider.getProviderName(), credential);
                     }
+                    return;
                 } else {
                     log.debug("Received {} error from device token endpoint for user {}; will retry...", response.getError(), userCode);
                     if (response.getError() == DeviceFlowError.SLOW_DOWN) {

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/AuthenticationController.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/AuthenticationController.java
@@ -5,7 +5,9 @@ import com.github.philippheuer.credentialmanager.identityprovider.OAuth2Identity
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 
 public abstract class AuthenticationController {
 
@@ -37,5 +39,25 @@ public abstract class AuthenticationController {
      * @param scopes                 Requested scopes
      */
     public abstract void startOAuth2AuthorizationCodeGrantType(OAuth2IdentityProvider oAuth2IdentityProvider, String redirectUrl, List<Object> scopes);
+
+    /**
+     * Starts the Device Authorization Grant Flow for the specified OAuth2 Identity Provider
+     * <p>
+     * This protocol only requires a one-way channel in order to maximize the viability of the protocol
+     * in restricted environments, like an application running on a TV that is only capable of outbound requests.
+     * <p>
+     * It starts by requesting a verification link from the authorization server that should be presented to the user.
+     * The user navigates to the page, inserts the {@link DeviceAuthorization#getUserCode()}, and authorizes the app.
+     * Finally, the {@code callback} will be invoked with the authorized device token (in an ideal scenario).
+     *
+     * @param oAuth2IdentityProvider OAuth2 Identity Provider
+     * @param scopes                 Requested scopes
+     * @param callback               Consumes the final {@link DeviceTokenResponse}, containing a credential or un-retryable error
+     * @return {@link DeviceAuthorization} so the completed verification uri can be presented to the end user
+     */
+    public DeviceAuthorization startOAuth2DeviceAuthorizationGrantType(OAuth2IdentityProvider oAuth2IdentityProvider, Collection<Object> scopes, Consumer<DeviceTokenResponse> callback) {
+        // default method body to avoid a breaking change
+        throw new UnsupportedOperationException("This controller does not implement the Device Authorization Grant Flow.");
+    }
 
 }

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
@@ -14,6 +14,7 @@ import okhttp3.HttpUrl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -73,6 +74,18 @@ public class DeviceAuthorization {
     @JsonAnyGetter
     @JsonAnySetter
     private Map<String, Object> customProperties = new HashMap<>(0);
+
+    /**
+     * The timestamp the Device Authorization response was received.
+     */
+    private Instant issuedAt = Instant.now(); // not in the RFC
+
+    /**
+     * @return the approximate timestamp when this device and user code tuple will no longer be valid.
+     */
+    public Instant getExpiresAt() {
+        return issuedAt.plusSeconds(this.expiresIn);
+    }
 
     /**
      * @return the verification uri with the populated user_code query parameter.

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
@@ -1,0 +1,88 @@
+package com.github.philippheuer.credentialmanager.domain;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import okhttp3.HttpUrl;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The response from the device authorization request.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8628#section-3.2">RFC</a>
+ */
+@Data
+@Setter(AccessLevel.PRIVATE)
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class DeviceAuthorization {
+
+    /**
+     * The device verification code.
+     */
+    @NotNull
+    private String deviceCode;
+
+    /**
+     * The end-user verification code.
+     */
+    @NotNull
+    private String userCode;
+
+    /**
+     * The end-user verification URI on the authorization server.
+     */
+    @NotNull
+    private String verificationUri;
+
+    /**
+     * The lifetime in seconds of the {@link #getDeviceCode()} and {@link #getUserCode()}..
+     */
+    private int expiresIn;
+
+    /**
+     * The minimum amount of time in seconds that the client
+     * should wait between polling requests to the token endpoint.
+     */
+    private int interval = 5; // RFC: "If no value is provided, clients MUST use 5 as the default."
+
+    /**
+     * A verification URI that includes the {@code user_code}
+     * (or other information with the same function as the {@code user_code}),
+     * which is designed for non-textual transmission.
+     */
+    @Nullable
+    @Getter(AccessLevel.PROTECTED) // avoid confusion with #getCompleteUri
+    private String verificationUriComplete;
+
+    /**
+     * @return the verification uri with the populated user_code query parameter.
+     */
+    public String getCompleteUri() {
+        if (verificationUriComplete != null && !verificationUriComplete.isEmpty()) {
+            return verificationUriComplete;
+        }
+        HttpUrl url = HttpUrl.parse(verificationUri);
+        if (url == null) {
+            return null; // should never happen for well-behaved auth services
+        }
+        // RFC explicitly recommends against including user_code in the verification URI
+        // but just in case some auth service does this anyway, avoid duplicating query param
+        if (this.userCode.equals(url.queryParameter("user_code"))) {
+            return verificationUri;
+        }
+        // append user_code to the verification uri
+        return url.newBuilder()
+                .addQueryParameter("user_code", this.userCode)
+                .build()
+                .toString();
+    }
+
+}

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
@@ -1,5 +1,7 @@
 package com.github.philippheuer.credentialmanager.domain;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
@@ -11,6 +13,9 @@ import lombok.Setter;
 import okhttp3.HttpUrl;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The response from the device authorization request.
@@ -61,6 +66,13 @@ public class DeviceAuthorization {
     @Nullable
     @Getter(AccessLevel.PROTECTED) // avoid confusion with #getCompleteUri
     private String verificationUriComplete;
+
+    /**
+     * Contains any non-standardized properties in the initial device authorization response.
+     */
+    @JsonAnyGetter
+    @JsonAnySetter
+    private Map<String, Object> customProperties = new HashMap<>(0);
 
     /**
      * @return the verification uri with the populated user_code query parameter.

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorization.java
@@ -2,6 +2,7 @@ package com.github.philippheuer.credentialmanager.domain;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AccessLevel;
@@ -83,8 +84,9 @@ public class DeviceAuthorization {
     /**
      * @return the approximate timestamp when this device and user code tuple will no longer be valid.
      */
+    @JsonIgnore // in case of an auth server deviating from the RFC
     public Instant getExpiresAt() {
-        return issuedAt.plusSeconds(this.expiresIn);
+        return expiresIn > 0 ? issuedAt.plusSeconds(this.expiresIn) : Instant.MAX;
     }
 
     /**

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceFlowError.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceFlowError.java
@@ -1,0 +1,99 @@
+package com.github.philippheuer.credentialmanager.domain;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Standardized possible error codes from
+ * {@link com.github.philippheuer.credentialmanager.identityprovider.OAuth2IdentityProvider#getDeviceAccessToken(String)}.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8628#section-3.5">RFC 8628, Section 3.5</a>
+ */
+public enum DeviceFlowError {
+
+    /**
+     * The authorization request is still pending as the end user hasn't yet completed the user-interaction steps.
+     */
+    AUTHORIZATION_PENDING,
+
+    /**
+     * A variant of {@link #AUTHORIZATION_PENDING}, the authorization request is still pending and polling
+     * should continue, but the interval MUST be increased by 5 seconds for this and all subsequent requests.
+     */
+    SLOW_DOWN,
+
+    /**
+     * The authorization request was denied.
+     */
+    ACCESS_DENIED,
+
+    /**
+     * The "device_code" has expired, and the device authorization session has concluded.
+     * The client MAY commence a new device authorization request but SHOULD wait for
+     * user interaction before restarting to avoid unnecessary polling.
+     */
+    EXPIRED_TOKEN,
+
+    /**
+     * The request is missing a required parameter, includes an unsupported parameter value (other than grant type),
+     * repeats a parameter, includes multiple credentials, utilizes more than one mechanism
+     * for authenticating the client, or is otherwise malformed.
+     * <p>
+     * This should not occur from {@link com.github.philippheuer.credentialmanager.identityprovider.OAuth2IdentityProvider}
+     * unless the authorization server does not strictly follow the RFC.
+     */
+    INVALID_REQUEST,
+
+    /**
+     * Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method).
+     * <p>
+     * This should not occur from {@link com.github.philippheuer.credentialmanager.authcontroller.DeviceFlowController}.
+     */
+    INVALID_CLIENT,
+
+    /**
+     * The provided authorization grant is invalid, expired, revoked, or was issued to another client.
+     */
+    INVALID_GRANT,
+
+    /**
+     * The authenticated client is not authorized to use this authorization grant type.
+     */
+    UNAUTHORIZED_CLIENT,
+
+    /**
+     * The authorization grant type is not supported by the authorization server.
+     */
+    UNSUPPORTED_GRANT_TYPE,
+
+    /**
+     * The auth server sent an error that is not standardized in the
+     * Device Authorization Grant RFC or OAuth 2.0 Authorization Framework RFC.
+     */
+    UNKNOWN;
+
+    private static final Map<String, DeviceFlowError> MAPPINGS = Arrays.stream(values())
+            .collect(Collectors.toMap(Enum::toString, Function.identity()));
+
+    /**
+     * Whether to keep retrying the access token request.
+     */
+    public boolean shouldRetry() {
+        return this == AUTHORIZATION_PENDING || this == SLOW_DOWN;
+    }
+
+    @Override
+    public String toString() {
+        return this.name().toLowerCase();
+    }
+
+    /**
+     * @param code The error code as a lowercase string (as defined by the RFC)
+     * @return {@link DeviceFlowError}
+     */
+    public static DeviceFlowError from(String code) {
+        return MAPPINGS.getOrDefault(code, UNKNOWN);
+    }
+}

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceTokenResponse.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/DeviceTokenResponse.java
@@ -1,0 +1,30 @@
+package com.github.philippheuer.credentialmanager.domain;
+
+import lombok.Value;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Device Access Token Response, yielded by
+ * {@link com.github.philippheuer.credentialmanager.identityprovider.OAuth2IdentityProvider#getDeviceAccessToken(String)}.
+ * <p>
+ * If the user has approved the grant, {@link #getCredential()} will be populated.
+ * Otherwise, {@link #getError()} will be present.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc8628#section-3.5">RFC 8628, Section 3.5</a>
+ */
+@Value
+public class DeviceTokenResponse {
+
+    /**
+     * The device token, given the user has approved the grant.
+     */
+    @Nullable
+    OAuth2Credential credential;
+
+    /**
+     * A potentially-retryable error when attempting to obtain the device token.
+     */
+    @Nullable
+    DeviceFlowError error;
+
+}

--- a/src/main/java/com/github/philippheuer/credentialmanager/identityprovider/DefaultOAuth2IdentityProvider.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/identityprovider/DefaultOAuth2IdentityProvider.java
@@ -39,7 +39,25 @@ public class DefaultOAuth2IdentityProvider extends OAuth2IdentityProvider {
      * @param proxy Proxy for HTTP Requests
      */
     public DefaultOAuth2IdentityProvider(String providerName, String providerType, String clientId, String clientSecret, String authUrl, String tokenUrl, String redirectUrl, String tokenEndpointPostType, Proxy proxy) {
-        super(providerName, providerType, clientId, clientSecret, authUrl, tokenUrl, redirectUrl, proxy);
+        this(providerName, providerType, clientId, clientSecret, authUrl, tokenUrl, null, redirectUrl, tokenEndpointPostType, proxy);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param providerName          Provider Name
+     * @param providerType          Provider Type
+     * @param clientId              Client ID
+     * @param clientSecret          Client Secret
+     * @param authUrl               Auth URL
+     * @param tokenUrl              Token URL
+     * @param deviceUrl             Device Flow URL
+     * @param redirectUrl           Redirect URL
+     * @param tokenEndpointPostType Token Endpoint Post Type
+     * @param proxy                 Proxy for HTTP Requests
+     */
+    public DefaultOAuth2IdentityProvider(String providerName, String providerType, String clientId, String clientSecret, String authUrl, String tokenUrl, String deviceUrl, String redirectUrl, String tokenEndpointPostType, Proxy proxy) {
+        super(providerName, providerType, clientId, clientSecret, authUrl, tokenUrl, deviceUrl, redirectUrl, proxy);
 
         this.tokenEndpointPostType = tokenEndpointPostType != null ? tokenEndpointPostType : this.tokenEndpointPostType;
     }

--- a/src/test/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowControllerTest.java
+++ b/src/test/java/com/github/philippheuer/credentialmanager/authcontroller/DeviceFlowControllerTest.java
@@ -1,0 +1,35 @@
+package com.github.philippheuer.credentialmanager.authcontroller;
+
+import com.github.philippheuer.credentialmanager.domain.DeviceAuthorization;
+import com.github.philippheuer.credentialmanager.identityprovider.DefaultOAuth2IdentityProvider;
+import com.github.philippheuer.credentialmanager.util.ProxyHelper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+class DeviceFlowControllerTest {
+
+    @Test
+    @Tag("integration")
+    @Disabled
+    void testTwitch() throws InterruptedException {
+        DefaultOAuth2IdentityProvider ip = new DefaultOAuth2IdentityProvider("twitch", "oauth2", "ipfj51ut03jud7jqdy7em925dg7k2l", null, "https://id.twitch.tv/oauth2/authorize", "https://id.twitch.tv/oauth2/token", "https://id.twitch.tv/oauth2/device", null, "QUERY", ProxyHelper.selectProxy());
+        CountDownLatch latch = new CountDownLatch(1);
+        DeviceFlowController controller = new DeviceFlowController();
+        DeviceAuthorization req = controller.startOAuth2DeviceAuthorizationGrantType(ip, Arrays.asList("user:read:email", "user:read:broadcast"), resp -> {
+            log.info("Device Access Token callback triggered: {}", resp);
+            latch.countDown();
+        });
+        log.debug(req.toString());
+        log.info("The user should now visit: {}", req.getCompleteUri());
+        latch.await(req.getExpiresIn(), TimeUnit.SECONDS);
+        controller.close();
+    }
+
+}

--- a/src/test/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorizationTest.java
+++ b/src/test/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorizationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DeviceAuthorizationTest {
@@ -26,6 +27,8 @@ class DeviceAuthorizationTest {
         String json = "{\"device_code\":\"helloWorld\",\"expires_in\":1800,\"interval\":5,\"user_code\":\"ABCDEFGH\"," +
                 "\"verification_uri\":\"https://www.twitch.tv/activate?device-code=ABCDEFGH\"}";
         DeviceAuthorization resp = MAPPER.readValue(json, DeviceAuthorization.class);
+        assertNotNull(resp.getIssuedAt());
+        assertNotNull(resp.getExpiresAt());
         assertEquals("helloWorld", resp.getDeviceCode());
         assertEquals("ABCDEFGH", resp.getUserCode());
         assertEquals(1800, resp.getExpiresIn());

--- a/src/test/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorizationTest.java
+++ b/src/test/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorizationTest.java
@@ -1,0 +1,36 @@
+package com.github.philippheuer.credentialmanager.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DeviceAuthorizationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Twitch's Device Authorization response deviates from the RFC in that:
+     * <ul>
+     *     <li>The {@code verification_uri} includes the {@code user_code} value, despite the RFC recommending against this</li>
+     *     <li>The {@code verification_uri} calls the value associated with {@code user_code} as {@code device-code}</li>
+     * </ul>
+     * Regardless, the output of {@link DeviceAuthorization#getCompleteUri()} works as expected in the browser.
+     *
+     * @see <a href="https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#device-code-grant-flow">Twitch Documentation</a>
+     */
+    @Test
+    void deserializeTwitch() throws JsonProcessingException {
+        String json = "{\"device_code\":\"helloWorld\",\"expires_in\":1800,\"interval\":5,\"user_code\":\"ABCDEFGH\"," +
+                "\"verification_uri\":\"https://www.twitch.tv/activate?device-code=ABCDEFGH\"}";
+        DeviceAuthorization resp = MAPPER.readValue(json, DeviceAuthorization.class);
+        assertEquals("helloWorld", resp.getDeviceCode());
+        assertEquals("ABCDEFGH", resp.getUserCode());
+        assertEquals(1800, resp.getExpiresIn());
+        assertEquals(5, resp.getInterval());
+        assertEquals("https://www.twitch.tv/activate?device-code=ABCDEFGH", resp.getVerificationUri());
+        assertEquals("https://www.twitch.tv/activate?device-code=ABCDEFGH&user_code=ABCDEFGH", resp.getCompleteUri());
+    }
+
+}

--- a/src/test/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorizationTest.java
+++ b/src/test/java/com/github/philippheuer/credentialmanager/domain/DeviceAuthorizationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DeviceAuthorizationTest {
 
@@ -31,6 +32,17 @@ class DeviceAuthorizationTest {
         assertEquals(5, resp.getInterval());
         assertEquals("https://www.twitch.tv/activate?device-code=ABCDEFGH", resp.getVerificationUri());
         assertEquals("https://www.twitch.tv/activate?device-code=ABCDEFGH&user_code=ABCDEFGH", resp.getCompleteUri());
+        assertTrue(resp.getCustomProperties().isEmpty());
+    }
+
+    @Test
+    void deserializeCustom() throws JsonProcessingException {
+        String json = "{\"device_code\":\"helloWorld\",\"expires_in\":1800,\"interval\":5,\"user_code\":\"ABCDEFGH\"," +
+                "\"verification_uri\":\"https://activate.example.com\",\"foo\":\"bar\",\"bar\":\"baz\"}";
+        DeviceAuthorization resp = MAPPER.readValue(json, DeviceAuthorization.class);
+        assertEquals(2, resp.getCustomProperties().size());
+        assertEquals("bar", resp.getCustomProperties().get("foo"));
+        assertEquals("baz", resp.getCustomProperties().get("bar"));
     }
 
 }

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.showDateTime=true


### PR DESCRIPTION
Adds support for `OAuth 2.0 device authorization grant`, as described in [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628).

Tested against Twitch's implementation: https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#device-code-grant-flow
