### PR TITLE
feat: add refreshCredentialOrThrow, isExpired, getExpiresAt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
     api("org.slf4j:slf4j-api:2.0.17")
     testImplementation("org.slf4j:slf4j-simple:2.0.17")
 
+    // annotations
+    implementation("org.jetbrains:annotations:26.0.2")
+
     // Commons Lang
     implementation("org.apache.commons:commons-lang3:3.17.0")
 

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/OAuth2Credential.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/OAuth2Credential.java
@@ -213,6 +213,23 @@ public class OAuth2Credential extends Credential {
     }
 
     /**
+     * Calculates the approximate timestamp when this token will no longer be valid.
+     *
+     * <ul>
+     *   <li>If {@code issuedAt} is {@code null}, the token is considered expired - {@code Instant.MIN}.</li>
+     *   <li>If {@code expiresIn} is {@code null}, the token is considered to never expire - {@code Instant.MAX}.</li>
+     * </ul>
+     *
+     * @return Instant when the token expires
+     */
+    @JsonIgnore
+    public Instant getExpiresAt() {
+        if (issuedAt == null) return Instant.MIN; // missing issuedAt timestamp
+        if (expiresIn == null) return Instant.MAX; // no expiration
+        return expiresIn > 0 ? issuedAt.plusSeconds(this.expiresIn) : Instant.MAX;
+    }
+
+    /**
      * Checks whether the token has expired.
      *
      * <ul>
@@ -224,9 +241,8 @@ public class OAuth2Credential extends Credential {
      *
      * @return {@code true} if the token has expired, {@code false} otherwise
      */
+    @JsonIgnore
     public boolean isExpired() {
-        if (issuedAt == null) return true; // missing issuedAt timestamp
-        if (expiresIn == null) return false; // no expiration
-        return issuedAt.plusSeconds(expiresIn).isBefore(Instant.now());
+        return Instant.now().isAfter(getExpiresAt());
     }
 }

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/OAuth2Credential.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/OAuth2Credential.java
@@ -211,4 +211,22 @@ public class OAuth2Credential extends Credential {
     public void setReceivedAt(Instant receivedAt) {
         this.issuedAt = receivedAt;
     }
+
+    /**
+     * Checks whether the token has expired.
+     *
+     * <ul>
+     *   <li>If {@code issuedAt} is {@code null}, the token is considered expired.</li>
+     *   <li>If {@code expiresIn} is {@code null}, the token is considered to never expire.</li>
+     *   <li>Otherwise, the token is considered expired, if the current time is after
+     *       {@code issuedAt + expiresIn} seconds.</li>
+     * </ul>
+     *
+     * @return {@code true} if the token has expired, {@code false} otherwise
+     */
+    public boolean isExpired() {
+        if (issuedAt == null) return true; // missing issuedAt timestamp
+        if (expiresIn == null) return false; // no expiration
+        return issuedAt.plusSeconds(expiresIn).isBefore(Instant.now());
+    }
 }

--- a/src/main/java/com/github/philippheuer/credentialmanager/domain/OAuth2Credential.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/domain/OAuth2Credential.java
@@ -226,7 +226,7 @@ public class OAuth2Credential extends Credential {
     public Instant getExpiresAt() {
         if (issuedAt == null) return Instant.MIN; // missing issuedAt timestamp
         if (expiresIn == null) return Instant.MAX; // no expiration
-        return expiresIn > 0 ? issuedAt.plusSeconds(this.expiresIn) : Instant.MAX;
+        return issuedAt.plusSeconds(this.expiresIn);
     }
 
     /**

--- a/src/main/java/com/github/philippheuer/credentialmanager/util/TokenResponseUtil.java
+++ b/src/main/java/com/github/philippheuer/credentialmanager/util/TokenResponseUtil.java
@@ -1,0 +1,34 @@
+package com.github.philippheuer.credentialmanager.util;
+
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
+@UtilityClass
+@ApiStatus.Internal
+public class TokenResponseUtil {
+    /**
+     * Parses the expires_in attribute from a token response.
+     *
+     * @param value the object to parse
+     * @return the parsed integer value, or null if the value is null
+     * @throws IllegalArgumentException if the value is of an unexpected type or cannot be parsed
+     */
+    @Nullable
+    public Integer parseExpiresIn(Object value) throws IllegalArgumentException {
+        if (value instanceof Integer) {
+            return (Integer) value;
+        } else if (value instanceof String) {
+            // not rfc compliant, but seen in the wild
+            try {
+                return Integer.parseInt((String) value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid expires_in string value: " + value, e);
+            }
+        } else if (value == null) {
+            return null;
+        }
+
+        throw new IllegalArgumentException("Unsupported expires_in type: " + value.getClass().getName());
+    }
+}

--- a/src/test/java/com/github/philippheuer/credentialmanager/CredentialManagerTest.java
+++ b/src/test/java/com/github/philippheuer/credentialmanager/CredentialManagerTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
@@ -24,7 +26,7 @@ public class CredentialManagerTest {
         CredentialManager credentialManager = CredentialManagerBuilder.builder().build();
 
         // asserts
-        assertTrue(credentialManager.getStorageBackend() != null, "Storage Backend not registered!");
+        assertNotNull(credentialManager.getStorageBackend(), "Storage Backend not registered!");
     }
 
     /**
@@ -42,7 +44,7 @@ public class CredentialManagerTest {
         credentialManager.addCredential("default", credential);
 
         // asserts
-        assertTrue(credentialManager.getCredentials().size() == 1, "Credential wasn't added!");
+        assertEquals(1, credentialManager.getCredentials().size(), "Credential wasn't added!");
     }
 
 }

--- a/src/test/java/com/github/philippheuer/credentialmanager/domain/OAuth2CredentialTest.java
+++ b/src/test/java/com/github/philippheuer/credentialmanager/domain/OAuth2CredentialTest.java
@@ -1,0 +1,62 @@
+package com.github.philippheuer.credentialmanager.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OAuth2CredentialTest {
+    @Test
+    void testUpdateCredential_ValuesAreUpdated() {
+        OAuth2Credential originalCred = new OAuth2Credential("test", "original-token", "original-refresh", "userId", "userName", Instant.now(), 3600, null, null);
+        OAuth2Credential updatedCred = new OAuth2Credential("test", "updated-token", "updated-refresh", "userId2", "userName2", Instant.ofEpochSecond(1743465600), 7200, null, null);
+
+        originalCred.updateCredential(updatedCred);
+
+        assertEquals("updated-token", originalCred.getAccessToken(), "Access token should be updated");
+        assertEquals("updated-refresh", originalCred.getRefreshToken(), "Refresh token should be updated");
+        assertEquals("userId2", originalCred.getUserId(), "User ID should not be updated");
+        assertEquals("userName2", originalCred.getUserName(), "User name should not be updated");
+        assertEquals(Instant.ofEpochSecond(1743465600), updatedCred.getIssuedAt(), "IssuedAt should not be updated");
+        assertEquals(7200, originalCred.getExpiresIn(), "ExpiresIn should be updated");
+    }
+
+    @Test
+    void testIsExpired_whenIssuedAtIsNull_returnsTrue() {
+        OAuth2Credential credential = new OAuth2Credential("test", "token");
+        credential.setIssuedAt(null);
+        credential.setExpiresIn(3600);
+
+        assertTrue(credential.isExpired(), "Token is considered expired when issuedAt is null");
+    }
+
+    @Test
+    void testIsExpired_whenExpiresInIsNull_returnsFalse() {
+        OAuth2Credential credential = new OAuth2Credential("test", "token");
+        credential.setIssuedAt(Instant.now().minusSeconds(10_000));
+        credential.setExpiresIn(null);
+
+        assertFalse(credential.isExpired(), "Token should not expire when expiresIn is null");
+    }
+
+    @Test
+    void testIsExpired_whenTokenIsStillValid_returnsFalse() {
+        OAuth2Credential credential = new OAuth2Credential("test", "token");
+        credential.setIssuedAt(Instant.now().minusSeconds(60)); // issued 1 minute ago
+        credential.setExpiresIn(3600); // valid for 1 hour
+
+        assertFalse(credential.isExpired(), "Token should not have expired yet");
+    }
+
+    @Test
+    void testIsExpired_whenTokenHasExpired_returnsTrue() {
+        OAuth2Credential credential = new OAuth2Credential("test", "token");
+        credential.setIssuedAt(Instant.now().minusSeconds(7200)); // issued 2 hours ago
+        credential.setExpiresIn(3600); // valid for 1 hour
+
+        assertTrue(credential.isExpired(), "Token should have expired");
+    }
+}


### PR DESCRIPTION
`OAuth2IdentityProvider`:
- log previously ignored errors in `refreshCredential`
- add `refreshCredentialOrThrow`
- fix for misbehaving auth services that return `expires_in` as string

Adds some utility methods to `OAuth2Credential`:
- `OAuth2Credential#getExpiresAt()`
- `OAuth2Credential#isExpired()`